### PR TITLE
Null safety

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,9 +1,10 @@
 name: example
 description: A new Flutter project.
 version: 1.0.0+1
+publish_to: none
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -17,5 +18,4 @@ dev_dependencies:
 
 
 flutter:
-
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,10 @@
 name: fontisto_flutter
 description: Provides over 1000 (update..) additional icons to use in your apps.
 version: 3.1.2
-author: Hoàng Công Minh <hoangminhh17@gmail.com>
 homepage: https://github.com/hcminh/fontisto_flutter
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.0.0"
 
 dependencies:


### PR DESCRIPTION
Added null safety.

Note: removed `author` field as it's been [deprecated](https://dart.dev/tools/pub/pubspec#authorauthors), also added `publish_to: none` to the example project. 